### PR TITLE
TRYING TO RESOLVE CODACY ISSUES ON CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -50,7 +50,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the [project team][contribution contact]. All
+reported by contacting the [project team][contribution contact] . All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -63,9 +63,9 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the  Contributor Covenant,  version 1.4,
-available at  [contributor covenant][homepage].
+available at [contributor covenant][homepage] .
 
-For answers to common questions about this code of conduct, see [faq][faq-link].
+For answers to common questions about this code of conduct, see [faq][faq-link] .
 
 <!-- Definitions -->
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,21 +65,10 @@ members of the project's leadership.
 This Code of Conduct is adapted from the  Contributor Covenant,  version 1.4,
 available at [contributor covenant][homepage] .
 
-This is a test sentence for inline links: [Visit GitHub!](https://www.github.com)
-
-This is a test sentence for referenced links: Here's [yet another link][another-link].
-
-This test a link to another document in the project: [read our readme.md][infile]
-
 For answers to common questions about this code of conduct, see [faq][faq-link] .
-
 
 [faq-link]: https://www.contributor-covenant.org/faq
 
 [contributor covenant]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
-
-[another-link]: https://www.google.com target="_blank"
-
-[infile]: README.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -50,7 +50,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the [project team][contribution contact] . All
+reported by contacting the [project team](buildforsdg@andela.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -72,9 +72,7 @@ This is a test sentence for referenced links: Here's [yet another link][another-
 For answers to common questions about this code of conduct, see [faq][faq-link] .
 
 <!-- Definitions -->
-
-[contribution contact] : buildforsdg@andela.com
-[faq-link]: https://www.contributor-covenant.org/faq
-[contributor covenant]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-[homepage]: https://www.contributor-covenant.org
-[another-link]: www.google.com
+[faq-link] : https://www.contributor-covenant.org/faq
+[contributor covenant] : https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+[homepage] : https://www.contributor-covenant.org
+[another-link] : https://www.google.com

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -13,18 +13,18 @@ appearance, race, religion, or sexual identity and orientation.
 
 Examples of behavior that contributes to creating a positive environment
 include:
-  * Using welcoming and inclusive language
-  * Being respectful of differing viewpoints and experiences
-  * Gracefully accepting constructive criticism
-  * Focusing on what is best for the community
-  * Showing empathy towards other community members
+* Using welcoming and inclusive language  
+* Being respectful of differing viewpoints and experiences  
+* Gracefully accepting constructive criticism  
+* Focusing on what is best for the community  
+* Showing empathy towards other community members  
 
 Examples of unacceptable behavior by participants include:
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+* The use of sexualized language or imagery and unwelcome sexual attention or advances  
+* Trolling, insulting/derogatory comments, and personal or political attacks  
+* Public or private harassment  
+* Publishing others' private information, such as a physical or electronic address, without explicit permission  
+* Other conduct which could reasonably be considered inappropriate in a professional setting  
 
 ## Our Responsibilities
 
@@ -50,7 +50,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [contribution contact]. All
+reported by contacting the [project team][contribution contact]. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -63,13 +63,13 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the  Contributor Covenant,  version 1.4,
-available at  [contributor covenant] [homepage].
+available at  [contributor covenant][homepage].
 
 For answers to common questions about this code of conduct, see [faq][faq-link].
 
 <!-- Definitions -->
 
 [contribution contact] : buildforsdg@andela.com
-[faq link] : https://www.contributor-covenant.org/faq
-[contributor covenant] : https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-[homepage] : https://www.contributor-covenant.org
+[faq-link]: https://www.contributor-covenant.org/faq
+[contributor covenant]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+[homepage]: https://www.contributor-covenant.org

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -50,7 +50,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the [project team](buildforsdg@andela.com). All
+reported by contacting the project team on buildforsdg@andela.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -65,14 +65,21 @@ members of the project's leadership.
 This Code of Conduct is adapted from the  Contributor Covenant,  version 1.4,
 available at [contributor covenant][homepage] .
 
-This is a test sentence for inline links: [Visit GitHub!](www.github.com)
+This is a test sentence for inline links: [Visit GitHub!](https://www.github.com)
 
 This is a test sentence for referenced links: Here's [yet another link][another-link].
 
+This test a link to another document in the project: [read our readme.md][infile]
+
 For answers to common questions about this code of conduct, see [faq][faq-link] .
 
-<!-- Definitions -->
-[faq-link] : https://www.contributor-covenant.org/faq
-[contributor covenant] : https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-[homepage] : https://www.contributor-covenant.org
-[another-link] : https://www.google.com
+
+[faq-link]: https://www.contributor-covenant.org/faq
+
+[contributor covenant]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+[another-link]: https://www.google.com
+
+[infile]: README.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,6 +65,10 @@ members of the project's leadership.
 This Code of Conduct is adapted from the  Contributor Covenant,  version 1.4,
 available at [contributor covenant][homepage] .
 
+This is a test sentence for inline links: [Visit GitHub!](www.github.com)
+
+This is a test sentence for referenced links: Here's [yet another link][another-link].
+
 For answers to common questions about this code of conduct, see [faq][faq-link] .
 
 <!-- Definitions -->
@@ -73,3 +77,4 @@ For answers to common questions about this code of conduct, see [faq][faq-link] 
 [faq-link]: https://www.contributor-covenant.org/faq
 [contributor covenant]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 [homepage]: https://www.contributor-covenant.org
+[another-link]: www.google.com

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -80,6 +80,6 @@ For answers to common questions about this code of conduct, see [faq][faq-link] 
 
 [homepage]: https://www.contributor-covenant.org
 
-[another-link]: https://www.google.com
+[another-link]: https://www.google.com target="_blank"
 
 [infile]: README.md


### PR DESCRIPTION
## Description
Added double spaces at the end of list item lines, and removed double spaces at the beginning of list item lines.
Worked on double brackets for referenced links. 
Note: The links navigates away from the current page at the moment, I will try to resolve this issue at a later stage. 


## How Has This Been Tested?
I worked through a markup tutorial to figure out what the correct syntax should be and implemented the changes.   I pushed the changes to my local repository until it looked correct.  


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
