### PR TITLE
CODACY recommendations implementation test

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -13,18 +13,18 @@ appearance, race, religion, or sexual identity and orientation.
 
 Examples of behavior that contributes to creating a positive environment
 include:  
-* Using welcoming and inclusive language   
-* Being respectful of differing viewpoints and experiences    
-* Gracefully accepting constructive criticism  
-* Focusing on what is best for the community  
-* Showing empathy towards other community members  
+*   Using welcoming and inclusive language   
+*   Being respectful of differing viewpoints and experiences    
+*   Gracefully accepting constructive criticism  
+*   Focusing on what is best for the community  
+*   Showing empathy towards other community members  
 
 Examples of unacceptable behavior by participants include:  
-* The use of sexualized language or imagery and unwelcome sexual attention or advances  
-* Trolling, insulting/derogatory comments, and personal or political attacks  
-* Public or private harassment  
-* Publishing others' private information, such as a physical or electronic address, without explicit permission  
-* Other conduct which could reasonably be considered inappropriate in a professional setting  
+*   The use of sexualized language or imagery and unwelcome sexual attention or advances  
+*   Trolling, insulting/derogatory comments, and personal or political attacks  
+*   Public or private harassment  
+*   Publishing others' private information, such as a physical or electronic address, without explicit permission  
+*   Other conduct which could reasonably be considered inappropriate in a professional setting  
 
 ## Our Responsibilities
 
@@ -50,8 +50,8 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team on buildforsdg@andela.com. All
-complaints will be reviewed and investigated and will result in a response that
+reported by contacting the project team - [email us](mailto:buildforsdg@andela.com).
+All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,14 +12,14 @@ appearance, race, religion, or sexual identity and orientation.
 ## Our Standards
 
 Examples of behavior that contributes to creating a positive environment
-include:
-* Using welcoming and inclusive language  
-* Being respectful of differing viewpoints and experiences  
+include:  
+* Using welcoming and inclusive language   
+* Being respectful of differing viewpoints and experiences    
 * Gracefully accepting constructive criticism  
 * Focusing on what is best for the community  
 * Showing empathy towards other community members  
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior by participants include:  
 * The use of sexualized language or imagery and unwelcome sexual attention or advances  
 * Trolling, insulting/derogatory comments, and personal or political attacks  
 * Public or private harassment  


### PR DESCRIPTION
## Description
The CODE_OF_CONDUCT.md file was changed various times to try and implement the CODACY recommendations.   Current PR implements two additional spaces after a list item indicator: 
* List item  
becomes: 
*   List item  

I still use two trailing spaces to ensure the next item will start on a new line but with a soft line break. 

Try to fix e-mail used directly by changing code to [linkname](mailto:email@email.mail)


Fixes issues in Codacy regarding CODE_OF_CONDUCT. md other than file name. 

## How Has This Been Tested?
I used a markdown file in another repository to get codacy feedback on my personal repository, as for some reason this repo did not want to update on codacy. 


## Screenshots (if applicable, else remove this line / section)


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
